### PR TITLE
Add AFLPlusPlus support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+FUZZ = afl-cc
 all: bin/utf8info
 
 ucd/UnicodeData.txt ucd/extracted/DerivedName.txt ucd/Unihan_Readings.txt update:
@@ -32,9 +33,19 @@ gen/table.h gen/table.cpp: bin/tablegen ucd/UnicodeData.txt ucd/extracted/Derive
 install: bin/utf8info
 	cp bin/utf8info /usr/local/bin/utf8info
 
+aflpp: ucd/UnicodeData.txt
+	@echo "Building table generator..."
+	@mkdir -p bin/
+	$(FUZZ) tablegen.cpp -std=c++17 -lstdc++ -o bin/tablegen -Wall -Wextra -Wpedantic
+	@echo "Building data tables..."
+	@mkdir -p gen/
+	@./bin/tablegen
+	@echo "Building utf8info..."
+	$(FUZZ) main.cpp gen/table.cpp -std=c++17 -lstdc++ -o bin/utf8info -Wall -Wextra -Wpedantic
+
 clean:
 	rm -rf bin/
 	rm -rf gen/
 	rm -rf ucd/
 
-.PHONY: all update install clean
+.PHONY: all update install clean aflpp


### PR DESCRIPTION
Now, the program can be compiled with AFLPP instrumentation:

$ make aflpp

Next, the program can be fuzzed. See https://aflplus.plus

Using AFLPP, I have managed to find some inputs that generate segfaults in the program. Let me know if you want them, or you can fuzz them yourself.

P.S. I am not very good with makefiles, I believe what I wrote is a bit redundant. Feel free to fix before merging.